### PR TITLE
- Moved where the package data was being generated so that any backen…

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,8 +17,6 @@ rules:
   max-len:
     - error
     - 200
-  one-var:
-    - off
   indent:
     - error
     - 4

--- a/index.js
+++ b/index.js
@@ -1,19 +1,17 @@
 
 const path = require('path');
 
-const
-    minimist = require('minimist'),
-    express = require('express'),
-    cors = require('cors'),
-    bodyParser = require('body-parser'),
-    morgan = require('morgan'),
-    compression = require('compression');
+const minimist = require('minimist');
+const express = require('express');
+const cors = require('cors');
+const bodyParser = require('body-parser');
+const morgan = require('morgan');
+const compression = require('compression');
 
-const
-    {BackendType} = require('./enum'),
-    dutyfreeBackend = require('./backend'),
-    routes = require('./routes'),
-    logger = require('./logger');
+const {BackendType} = require('./enum');
+const dutyfreeBackend = require('./backend');
+const routes = require('./routes');
+const logger = require('./logger');
 
 const STATIC_MAX_AGE = 1000 * 60 * 60 * 24 * 30;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,10 +1079,9 @@
       }
     },
     "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
     },
     "clone-stats": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.17.2",
     "chalk": "^2.0.1",
+    "clone": "^2.1.1",
     "compression": "^1.7.0",
     "cors": "^2.8.3",
     "express": "^4.15.3",


### PR DESCRIPTION
…d can use it generically

- Added `clone` package for foolproof object cloning